### PR TITLE
Fix isValidMedia() to accept TTS temp directory paths

### DIFF
--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -29,7 +29,18 @@ function isValidMedia(candidate: string, opts?: { allowSpaces?: boolean }) {
   }
 
   // Local paths: only allow safe relative paths starting with ./ that do not traverse upwards.
-  return candidate.startsWith("./") && !candidate.includes("..");
+  if (candidate.startsWith("./") && !candidate.includes("..")) {
+    return true;
+  }
+
+  // Allow temp directory paths for TTS output
+  if (candidate.startsWith("/var/folders/") || candidate.startsWith("/tmp/")) {
+    if (/\.(opus|mp3|ogg|wav|m4a|webm|mp4|jpg|jpeg|png|gif|webp)$/i.test(candidate)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function unwrapQuoted(value: string): string | undefined {


### PR DESCRIPTION
## Summary
Fixes #98 - TTS voice messages now properly deliver to Telegram by accepting temp directory paths in isValidMedia().

## Changes
- Modified `isValidMedia()` function in `src/media/parse.ts` to accept absolute paths from system temp directories (`/var/folders/` on macOS and `/tmp/` on Linux)
- Added validation for known media file extensions (opus, mp3, ogg, wav, m4a, webm, mp4, jpg, jpeg, png, gif, webp)

## Root Cause
The `isValidMedia()` function was only accepting HTTP(S) URLs and relative paths starting with `./`, causing TTS-generated audio files from temp directories to be rejected.

## Test Plan
- TTS-generated voice messages with paths like `/var/folders/.../voice-*.opus` should now be recognized as valid media
- Voice messages should successfully deliver to Telegram with the `audioAsVoice` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)